### PR TITLE
retrieving full execution history

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -44,11 +44,20 @@ export async function fetchExecutions(stepfunctions: StepFunctions, stateMachine
 }
 
 export async function fetchExecution(stepfunctions: StepFunctions, executionArn: StepFunctions.Arn): Promise<StepFunctions.GetExecutionHistoryOutput> {
-  const params: StepFunctions.GetExecutionHistoryInput = {
-    executionArn,
-    includeExecutionData: true,
-  };
+  var events:StepFunctions.HistoryEventList = [];
+  let nextToken = "0";
 
-  const response = await stepfunctions.getExecutionHistory(params).promise();
-  return response;
+  while (nextToken !== "") {
+    const params: StepFunctions.GetExecutionHistoryInput = {
+      executionArn,
+      includeExecutionData: true,
+      nextToken: nextToken
+    };
+
+    const response = await stepfunctions.getExecutionHistory(params).promise();
+    events.push(...response.events);
+    nextToken = response.nextToken ?? "";
+  }
+
+  return { events: events, nextToken: "" };
 }


### PR DESCRIPTION
Ran across this when running a local step function with more than 100 events in it's execution history.